### PR TITLE
Move most `node_modules` into the `deps` directory.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist/*
 node_modules/*
+deps/*
 libs/*

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,6 @@
 [ignore]
-.*/node_modules/webpack/.*
+.*/deps/.*
 [libs]
-./libs
+libs/
 [version]
 0.13.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@
 language: node_js
 node_js:
   - "0.12"
-install: npm install
+install:
+  - npm install
+  - pushd deps && npm install && popd
 before_script:
   - npm run lint
   - npm test

--- a/deps/package.json
+++ b/deps/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "shift-deps",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "devDependencies": {
+    "babel": "^5.6.23",
+    "babel-core": "^5.7.1",
+    "babel-loader": "^5.3.2",
+    "chai": "^3.0.0",
+    "immutable": "^3.7.4",
+    "node-libs-browser": "^0.5.2",
+    "react": "^0.13.3",
+    "react-immutable-proptypes": "^1.0.0",
+    "webpack": "^1.10.1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/editor/stateful-editor.js
+++ b/editor/stateful-editor.js
@@ -19,40 +19,56 @@
  */
 var React = require('react');
 
+// ignore unused and undef for the type definition
+/*eslint-disable*/
+type ReactClass<D, P, S, C: ReactComponent<D, P, S>> = Class<C>;
+/*eslint-enable*/
+
 type State = {
 	value: any,
 	initialValue: any,
 	isFocused: bool,
 };
 
-var StatefulEditor = React.createClass({
-	mixins: [React.addons.PureRenderMixin],
-	propTypes: {
-		field: React.PropTypes.string,
-		// What is the prop type for something that can be instanciated via
-		// React.createElement?
-		Component: React.PropTypes.any.isRequired,
-		editorProps: React.PropTypes.any,
-		onFocusNext: React.PropTypes.func.isRequired,
-		onFocusPrev: React.PropTypes.func.isRequired,
-		onFocus: React.PropTypes.func.isRequired,
-		onBlur: React.PropTypes.func.isRequired,
-		isFocused: React.PropTypes.bool.isRequired,
-		value: React.PropTypes.any,
-	},
+type callback = () => void;
+
+var undef;
+
+type DefaultProps = {
+	value: any,
+	editorProps: any,
+};
+
+type Props = {
+	editorProps: any,
+	Component: ReactClass,
+	value: any,
+	isFocused: bool,
+	onFocusNext: callback,
+	onFocusPrev: callback,
+	onFocus: callback,
+	onBlur: callback,
+	onChange: (value: any) => void,
+};
+
+class StatefulEditor extends React.Component<DefaultProps, Props, State> {
+	constructor(props: Props) {
+		super(props);
+		this.state = this.getInitialState();
+	}
 	getInitialState() : State {
 		return {
 			value: this.props.value,
 			initialValue: this.props.value,
 			isFocused: this.props.isFocused,
 		};
-	},
+	}
 	componentDidMount() : void {
 		if (this.props.isFocused) {
 			this.refs.editor.focus();
 		}
-	},
-	componentWillUpdate(nextProps : {value: any, isFocused: bool}, nextState: State) : void {
+	}
+	componentWillReceiveProps(nextProps : {value: any, isFocused: bool}) : void {
 		// Fixup the value
 		if (this.state.value !== nextProps.value) {
 			this.refs.editor.setValue(nextProps.value);
@@ -62,43 +78,43 @@ var StatefulEditor = React.createClass({
 		}
 
 		// Fixup the focused state
-		if (this.state.isFocused !== nextState.isFocused && this.state.isFocused !== nextProps.isFocused) {
-			// Store the newly commanded state
-			this.setState({
-				isFocused: nextProps.isFocused,
-			});
-
-			// Editor, do our bidding, please
-			if (nextProps.isFocused) {
-				this.refs.editor.focus();
-			} else {
-				this.refs.editor.blur();
-			}
-		}
-	},
+		// if (this.state.isFocused !== nextState.isFocused && this.state.isFocused !== nextProps.isFocused) {
+		// 	// Store the newly commanded state
+		// 	this.setState({
+		// 		isFocused: nextProps.isFocused,
+		// 	});
+		//
+		// 	// Editor, do our bidding, please
+		// 	if (nextProps.isFocused) {
+		// 		this.refs.editor.focus();
+		// 	} else {
+		// 		this.refs.editor.blur();
+		// 	}
+		// }
+	}
 	valueChanged(prevValue : any, nextValue : any) {
 		this.setState({
 			value: nextValue,
 		}, function() {
-			this.onChange(nextValue);
+			this.props.onChange(nextValue);
 		});
-	},
+	}
 	onFocus() : any {
 		this.setState({
 			isFocused: true,
 		}, function() {
 			this.props.onFocus();
 		});
-	},
+	}
 	onBlur() : any {
 		this.setState({
 			isFocused: false,
 		}, function() {
 			this.props.onBlur();
 		});
-	},
+	}
 	render() : React.Element {
-		var props = this.editorProps;
+		var props = this.props.editorProps;
 		if (props == null) {
 			props = {};
 		}
@@ -113,10 +129,27 @@ var StatefulEditor = React.createClass({
 			onBlur={this.onBlur}
 			onChange={this.valueChanged}
 		/>;
-	},
+	}
 	select() : void {
 		this.refs.editor.select();
-	},
-});
+	}
+}
 
+StatefulEditor.propTypes = {
+	// What is the prop type for something that can be instanciated via
+	// React.createElement?
+	Component: React.PropTypes.any.isRequired,
+	editorProps: React.PropTypes.any,
+	onFocusNext: React.PropTypes.func.isRequired,
+	onFocusPrev: React.PropTypes.func.isRequired,
+	onFocus: React.PropTypes.func.isRequired,
+	onBlur: React.PropTypes.func.isRequired,
+	isFocused: React.PropTypes.bool.isRequired,
+	value: React.PropTypes.any,
+};
+
+StatefulEditor.defaultProps = {
+	value: undef,
+	editorProps: {},
+};
 export {StatefulEditor};

--- a/editor/stateless-editor.js
+++ b/editor/stateless-editor.js
@@ -5,25 +5,55 @@
  *
  * @TODO: `select` implementation feels icky.
  */
-var React = require('react');
+import React from 'react';
 
-var StatelessEditor = React.createClass({
-	mixins: [React.addons.PureRenderMixin],
-	propTypes: {
-		field: React.PropTypes.string,
-		// What is the prop type for something that can be instanciated via
-		// React.createElement?
-		Component: React.PropTypes.any.isRequired,
-		editorProps: React.PropTypes.any,
-		onFocusNext: React.PropTypes.func.isRequired,
-		onFocusPrev: React.PropTypes.func.isRequired,
-		onFocus: React.PropTypes.func.isRequired,
-		onBlur: React.PropTypes.func.isRequired,
-		isFocused: React.PropTypes.bool.isRequired,
-		value: React.PropTypes.any,
-	},
+type fn = () => void;
+type changeFn<T> = (value: ?T) => void;
+
+// ignore unused and undef for the type definition
+/*eslint-disable*/
+type ReactClass<D, P, S, C: ReactComponent<D, P, S>> = Class<C>;
+/*eslint-enable*/
+
+type Props<T> = {
+	Component: ReactClass,
+	editorProps: any,
+	onFocusNext: fn,
+	onFocusPrev: fn,
+	onFocus: fn,
+	onBlur: fn,
+	onChange: changeFn<T>,
+	isFocused: bool,
+	value: ?T,
+};
+
+type DefaultProps<T> = {
+	editorProps: any,
+	value: ?T
+};
+
+type State = {};
+
+type Selectable = {
+	select: fn,
+};
+
+type Refs = {
+	editor: ?Selectable,
+};
+
+class StatelessEditor<T> extends React.Component<DefaultProps<T>, Props<T>, State> {
+	props: Props<T>;
+	refs: Refs;
+	constructor(props : Props<T>, context: any) {
+		super(props, context);
+		this.refs = {
+			editor: null,
+		};
+	}
+
 	render() : React.Element {
-		var props = this.editorProps;
+		var props = this.props.editorProps;
 		if (props == null) {
 			props = {};
 		}
@@ -36,12 +66,39 @@ var StatelessEditor = React.createClass({
 			onBlur={this.props.onBlur}
 			onFocusNext={this.props.onFocusNext}
 			onFocusPrev={this.props.onFocusPrev}
+			isFocused={this.props.isFocused}
 			onChange={this.props.onChange}
 		/>;
-	},
+	}
+
 	select() : void {
-		this.refs.editor.select();
-	},
-});
+		if (this.refs.editor != null) {
+			this.refs.editor.select();
+		} else {
+			throw new Error('editor ref not assigned');
+		}
+	}
+}
+
+StatelessEditor.propTypes = {
+	// What is the prop type for something that can be instanciated via
+	// React.createElement?
+	Component: React.PropTypes.any.isRequired,
+	editorProps: React.PropTypes.any,
+	onFocusNext: React.PropTypes.func.isRequired,
+	onFocusPrev: React.PropTypes.func.isRequired,
+	onFocus: React.PropTypes.func.isRequired,
+	onBlur: React.PropTypes.func.isRequired,
+	onChange: React.PropTypes.func.isRequired,
+	isFocused: React.PropTypes.bool.isRequired,
+	value: React.PropTypes.any,
+};
+
+var undef;
+
+StatelessEditor.defaultProps = {
+	value: undef,
+	editorProps: {},
+};
 
 export {StatelessEditor};

--- a/libs/chai.js
+++ b/libs/chai.js
@@ -1,0 +1,10 @@
+
+declare module 'chai' {
+	declare class Assert {
+		equal<T>(actual: T, expected: T, message: ?string) : void;
+		deepEqual<T>(actual: T, expected: T, message: ?string) : void;
+		isTrue(value: bool, message: ?string) : void;
+		isFalse(value: bool, message: ?string) : void;
+	}
+	declare var assert: Assert;
+}

--- a/libs/immutable.js
+++ b/libs/immutable.js
@@ -1,0 +1,15 @@
+declare module "immutable" {
+	declare class Iterable {
+	}
+
+	declare class ImmutableMap extends Iterable {
+
+	}
+
+	declare function Map() : ImmutableMap;
+	declare function List() : ImmutableMap;
+
+	declare class ImmutableList extends Iterable {
+	}
+
+}

--- a/libs/mocha.js
+++ b/libs/mocha.js
@@ -1,5 +1,3 @@
-/* @flow */
-
 type callback = () => void;
 
 declare var describe : (context: string, fn: callback) => void;

--- a/libs/react-addons.js
+++ b/libs/react-addons.js
@@ -1,0 +1,16 @@
+declare class ReactTestUtils {
+	createRenderer(): ReactShallowRenderer;
+}
+
+declare class ReactShallowRenderer {
+	render(element: ReactElement): void;
+	getRenderOutput(): ReactElement;
+}
+
+type Addons = {
+	TestUtils: ReactTestUtils
+}
+
+declare module 'react/addons' {
+	declare var addons : Addons;
+}

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Flow is a library for generating read and write scenario UI using React",
   "main": "dist/shift.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha --opts test/mocha.opts",
-    "test-spec": "./node_modules/mocha/bin/mocha --opts test/mocha.opts --reporter spec",
-    "test-watch": "./node_modules/mocha/bin/mocha --opts test/mocha.opts -w",
+    "test": "NODE_PATH=./deps/node_modules ./node_modules/mocha/bin/mocha --opts test/mocha.opts",
+    "test-spec": "NODE_PATH=./deps/node_modules ./node_modules/mocha/bin/mocha --opts test/mocha.opts --reporter spec",
+    "test-watch": "NODE_PATH=./deps/node_modules ./node_modules/mocha/bin/mocha --opts test/mocha.opts -w",
     "lint": "./node_modules/eslint/bin/eslint.js .",
-    "build": "./node_modules/webpack/bin/webpack.js --config webpack.config.js"
+    "build": "./deps/node_modules/webpack/bin/webpack.js --config webpack.config.js"
   },
   "keywords": [
     "react",
@@ -17,19 +17,11 @@
   "author": "Kaare Hoff Skovgaard <kaare@kaareskovgaard.net>",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "babel": "^5.6.14",
-    "babel-core": "^5.6.15",
-    "babel-eslint": "^3.1.20",
-    "babel-loader": "^5.3.1",
-    "chai": "^3.0.0",
+    "babel": "^5.6.23",
+    "babel-eslint": "^3.1.23",
     "eslint": "^0.24.0",
-    "eslint-plugin-react": "^2.6.4",
-    "immutable": "^3.7.4",
-    "mocha": "^2.2.5",
-    "node-libs-browser": "^0.5.2",
-    "react": "^0.13.3",
-    "react-immutable-proptypes": "^1.0.0",
-    "webpack": "^1.10.1"
+    "eslint-plugin-react": "^2.7.0",
+    "mocha": "^2.2.5"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,9 +14,17 @@ module.exports = {
 			{ test: /.*\.js$/, loader: 'babel-loader?stage=0' },
 		],
 	},
-	externals: {
-		'immutable': true,
-		'react': true,
-		'react-immutable-proptypes': true,
+	resolve: {
+		root: path.join(__dirname, 'deps'),
 	},
+	resolveLoader: {
+		root: path.join(__dirname, 'deps', 'node_modules'),
+	},
+	externals: [
+		{
+			'immutable': true,
+			'react': true,
+			'react-immutable-proptypes': true,
+		},
+	],
 };


### PR DESCRIPTION
Moved most runtime library dependencies into `deps` folder.
This is done to make flow happy as right now it gets kind of grumpy when stuff that can be imported (and is defined in external library code) is also present as a node module.

With this, many type errors start showing up, and doing things like this we should be able to get much more value from using flow.

I hope this will only have to be a temporary workaround, and looking at a couple of flow issues it should be.
