### PR TITLE
Output path in webpack from shift.js -> shift.umd.js.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = {
 	entry: path.join(__dirname, 'shift.js'),
 	output: {
 		path: path.join(__dirname, 'dist'),
-		filename: 'shift.js',
+		filename: 'shift.umd.js',
 		library: 'shift',
 		libraryTarget: 'umd',
 	},


### PR DESCRIPTION
Prepare support to output non webpacked build in ./dist folder.
